### PR TITLE
Build own flag override logic in prep. for removal from core

### DIFF
--- a/lib/request-object.js
+++ b/lib/request-object.js
@@ -17,19 +17,26 @@ function FFlipRequestObject(fflip, flags) {
 }
 
 /**
- * Sets the features for a given user
-  *
+ * Sets the features for a given user. Apply any override flags from the request if they exist.
+ *
  * @param {Object} user A user object to test criteria against for each feature
  * @return {void}
  */
 FFlipRequestObject.prototype.setForUser = function(user) {
-	this.features = this._fflip.getFeaturesForUser(user, this._flags);
+	this.features = this._fflip.getFeaturesForUser(user);
+
+	for (var overrideFeatureName in this._flags) {
+		if (this._flags.hasOwnProperty(overrideFeatureName) && this.features.hasOwnProperty(overrideFeatureName) && this._flags[overrideFeatureName] !== undefined) {
+			this.features[overrideFeatureName] = this._flags[overrideFeatureName];
+		}
+	}
+
 	this.isSet = true;
 };
 
 /**
  * Check if a user has a certain feature enabled/disabled
-  *
+ *
  * @param  {string} featureName The name of the feature to check for
  * @return {Boolean} True if feature is enabled, false otherwise
  * @throws {Error} If features have not yet been set (via setForUser())

--- a/tests/fflip-express-test.js
+++ b/tests/fflip-express-test.js
@@ -211,21 +211,11 @@ describe('fflip-express', function(){
 			});
 		});
 
-		it('req.fflip.setFeatures() should call getFeaturesForUser() with cookie flags', function(done) {
-			var spy = this.sandbox.spy(fflip, 'getFeaturesForUser');
-			expressIntegration.middleware(reqMock, resMock, function() {
-				reqMock.fflip.setForUser(userXYZ);
-				assert(fflip.getFeaturesForUser.calledOnce);
-				assert(fflip.getFeaturesForUser.calledWith(userXYZ, {fClosed: true}));
-				spy.restore();
-				done();
-			});
-		});
-
 		it('req.fflip.has() should get the correct features', function(done) {
 			expressIntegration.middleware(reqMock, resMock, function() {
 				reqMock.fflip.setForUser(userXYZ);
 				assert.strictEqual(reqMock.fflip.has('fOpen'), true);
+				// NOTE(fks) 05-03-2016: `fClosed` evals to false, but reqMock has an override cookie which sets it to true
 				assert.strictEqual(reqMock.fflip.has('fClosed'), true);
 				assert.strictEqual(reqMock.fflip.has('notafeature'), false);
 				done();


### PR DESCRIPTION
The ability of fflip "core" to handle feature overrides was only needed for express. Now that `fflip-express` is its own library that can handle this itself, core will be removing this syntax soon.
