### PR TITLE
Fix: Use of res.json(status, obj) is deprecated

### DIFF
--- a/lib/fflip-express.js
+++ b/lib/fflip-express.js
@@ -111,7 +111,7 @@ function FFlipExpressIntegration(fflip, options) {
 
 		// set new fflip cookie with new data
 		res.cookie(this.options.cookieName, flags, this.options.cookieOptions);
-		res.json(200, {
+		res.status(200).json({
 			feature: name,
 			action: action,
 			status: 200,


### PR DESCRIPTION
http://expressjs.com/en/4x/api.html#res.json
