### PR TITLE
Replace deprecated usage of res.json

### DIFF
--- a/lib/fflip-express.js
+++ b/lib/fflip-express.js
@@ -111,7 +111,7 @@ function FFlipExpressIntegration(fflip, options) {
 
 		// set new fflip cookie with new data
 		res.cookie(this.options.cookieName, flags, this.options.cookieOptions);
-		res.json(200, {
+		res.status(200).json({
 			feature: name,
 			action: action,
 			status: 200,


### PR DESCRIPTION
Fixes deprecation notice:

```
express deprecated res.json(status, obj): Use res.status(status).json(obj) instead node_modules/fflip-express/lib/fflip-express.js:114:7
```

This was [deprecated in Express 4.7.0, back in 2014](https://github.com/expressjs/express/blob/master/History.md#470--2014-07-25).